### PR TITLE
Chronological decades + colour-on-hover for archive thumbnails

### DIFF
--- a/scripts/app.jsx
+++ b/scripts/app.jsx
@@ -38,8 +38,7 @@ function Plate({ n }){
     <img
       src={`assets/archive/ant-${idx}.jpg`}
       alt=""
-      style={{ display:'block', width:'100%', height:'100%', objectFit:'cover',
-               filter:'grayscale(1) contrast(1.05)' }}
+      style={{ display:'block', width:'100%', height:'100%', objectFit:'cover' }}
     />
   );
 }
@@ -97,6 +96,8 @@ function layoutGroupMode(mode){
   const ordered = [...groups.entries()].sort((A, B) => {
     if (A[0] === "Unspecified") return 1;
     if (B[0] === "Unspecified") return -1;
+    // Decades read chronologically; all other modes stay sorted by size.
+    if (mode === "decade") return parseInt(A[0], 10) - parseInt(B[0], 10);
     return B[1].length - A[1].length;
   });
 

--- a/styles/exposition.css
+++ b/styles/exposition.css
@@ -387,7 +387,11 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
   overflow:hidden;
 }
 .island.spec .plate svg{ display:block; width:100%; height:100% }
-.island.spec .plate img{ display:block; width:100%; height:100%; object-fit:cover; filter:grayscale(1) contrast(1.05) }
+.island.spec .plate img{
+  display:block; width:100%; height:100%; object-fit:cover;
+  filter: grayscale(1) contrast(1.05);
+  transition: filter .35s ease;
+}
 .island.spec .info{ padding: .5rem .6rem .7rem }
 .island.spec .no{
   font-family: var(--f-mono); font-size: 10px;
@@ -552,7 +556,14 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
   overflow:hidden;
 }
 .island.thumb .plate svg{ display:block; width:100%; height:100% }
-.island.thumb .plate img{ display:block; width:100%; height:100%; object-fit:cover; filter:grayscale(1) contrast(1.05) }
+.island.thumb .plate img{
+  display:block; width:100%; height:100%; object-fit:cover;
+  filter: grayscale(1) contrast(1.05);
+  transition: filter .35s ease;
+}
+/* Hover any archive specimen → fade in the original colour photograph. */
+.island.thumb:hover .plate img,
+.island.spec:hover  .plate img{ filter: none; }
 .island.thumb .info{ padding: .3rem .4rem .4rem }
 .island.thumb .no{
   font-family: var(--f-mono); font-size: 9.5px; letter-spacing:.14em;


### PR DESCRIPTION
## Summary
- **Decade order is chronological.** `layoutGroupMode` now sorts decade keys by parsed year (1910s → 2020s) instead of by count. Other modes keep their existing size-desc ordering; Unspecified still goes last.
- **Hover an archive specimen → original colour photograph fades in.** Removed the inline grayscale filter from `<Plate>` so CSS owns it, added `transition: filter .35s ease` to the thumb/spec plate images, and a hover rule that drops the filter.

## Test plan
- [ ] Open the site, switch to `decade` grouping mode → cluster order reads 1910s through 2020s
- [ ] Switch to other grouping modes (`application`, `band`, `form`) → still sorted by size desc
- [ ] Hover any archive thumbnail → grayscale fades to colour
- [ ] Hover the spec card → same colour reveal
- [ ] Default (un-hovered) state remains grayscale everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)