### PR TITLE
remove tweaks/edit-mode button from chrome

### DIFF
--- a/scripts/app.jsx
+++ b/scripts/app.jsx
@@ -724,11 +724,6 @@ function App(){
           <kbd>drag</kbd> pan · <kbd>wheel</kbd> zoom · <kbd>shift+wheel</kbd> pan · <kbd>0</kbd> reset
         </div>
 
-        <button className="tweaks-toggle" type="button"
-          onClick={()=>window.postMessage({ type: '__activate_edit_mode' }, '*')}>
-          tweaks ⌥
-        </button>
-
         <div className="legend">
           <div className="row"><span className="sw t"/><span>island</span></div>
           <div className="row"><span className="sw"/><span>direct</span></div>

--- a/styles/exposition.css
+++ b/styles/exposition.css
@@ -131,16 +131,6 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
   letter-spacing:.12em; text-transform:uppercase;
   color:var(--muted);
 }
-.chrome .tweaks-toggle{
-  position:absolute; left: 1rem; top: 3rem;
-  pointer-events:auto;
-  font-family:var(--f-mono); font-size:10px;
-  letter-spacing:.12em; text-transform:uppercase;
-  background: var(--paper); color: var(--ink);
-  border:1px solid var(--ink); padding:.35rem .55rem;
-  cursor:pointer;
-}
-.chrome .tweaks-toggle:hover{ background:var(--ink); color:var(--paper) }
 
 /* Hidden grouping picker — opens on `g`, closes on Esc. Not chrome-bound
    because it's intentionally undiscoverable. */


### PR DESCRIPTION
## Summary
- Removes the `tweaks ⌥` button from the viewer chrome in `app.jsx`
- Removes associated `.chrome .tweaks-toggle` CSS from `exposition.css`

The button exposed an internal edit-mode postMessage hook to end viewers — not intended for the published exposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)