### PR TITLE
chore: remove daily schedule from notion-sync workflow

### DIFF
--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,9 +1,6 @@
 name: notion-sync
 
 on:
-  schedule:
-    # Daily at 06:00 UTC (≈ early morning CET / late evening US west)
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes the `cron: '0 6 * * *'` schedule trigger. Sync can still be run on demand via `workflow_dispatch` from the Actions tab, or locally with `NOTION_TOKEN=… node tools/sync-from-notion.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)