### PR TITLE
ci: add manual notion-sync-branch workflow

### DIFF
--- a/.github/workflows/notion-sync-branch.yml
+++ b/.github/workflows/notion-sync-branch.yml
@@ -1,0 +1,51 @@
+name: notion-sync-branch
+
+# Manual sync that regenerates data/islands.generated.js from Notion and commits
+# it straight back to the chosen branch (no PR). Use this to refresh a feature
+# branch with the latest Notion content using *that branch's* generator.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to sync and commit the regenerated file onto
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Pull from Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: node tools/sync-from-notion.mjs
+
+      - name: Run structural checks
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: node tools/check.mjs
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- data/islands.generated.js; then
+            echo "No changes to data/islands.generated.js"
+            exit 0
+          fi
+          git --no-pager diff --stat -- data/islands.generated.js
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/islands.generated.js
+          git commit -m "chore(notion): sync islands from Notion onto ${{ inputs.branch }}"
+          git push origin HEAD:${{ inputs.branch }}


### PR DESCRIPTION
Adds a workflow_dispatch workflow that regenerates data/islands.generated.js from Notion and commits it directly onto a given branch. Needed so feature branches can sync using their own generator. Workflow-only change.