### PR TITLE
Make the archive a layered browser instead of field sprawl

### DIFF
--- a/REPOSITORY_TASKS.md
+++ b/REPOSITORY_TASKS.md
@@ -1,0 +1,109 @@
+# Repository browser — follow-up tasks
+
+Four follow-ups on the archive→repository browser (PR #29, branch `feat/archive-browser`).
+Written so each can be picked up cold and run in parallel by separate agents.
+
+**Shared context**
+- Static site, no build. React 18 + Babel standalone in-browser. three.js for GLB models.
+- Run: open `index.html` or `python3 -m http.server`. Validate: `node tools/check.mjs`.
+- The field is a pannable 2D plane. The "archive" lives as a single node (`archive-node`)
+  that opens a full-screen layer (`ArchiveLayer`) with grouping modes + single-specimen mode.
+- Data: `window.SA_ARCHIVE` (49 entries, `data/archive.js`). Notion is source of truth;
+  `data/notion-mapping.json` maps images → Antenna Repository DB pages.
+
+**Parallelization / conflict map**
+- Tasks 1, 2, 3 all touch `scripts/app.jsx` and `styles/exposition.css` → real merge-conflict
+  risk if run fully in parallel. Recommend: do 1+2 together (small, same region), then 3.
+- Task 4 touches `data/archive.js` + `data/notion-mapping.json` only → fully independent,
+  safe to run in parallel with everything else.
+
+---
+
+## Task 1 — Rename "archive" → "repository" (UI text)
+
+**Goal:** user-visible strings say "repository", not "archive". CSS class names and internal
+ids (`archive-node`, `ax-*`, `sa-archive-open`, `SA_ARCHIVE_OPEN`) stay as-is — text only.
+
+**Files / lines (`scripts/app.jsx`):**
+- 101 — cluster-head `k: "archive"` (the big background wash label)
+- 403 — `<div className="k">archive</div>` (node header)
+- 404 — node subtitle `"{N} specimens · gathered, ongoing"` (review wording)
+- 413 — button `enter the archive →`
+- 486 — `aria-label="exit the archive"`
+- 489 — `<div className="ax-heading">archive<span>…</span></div>`
+- 803 — jumps `{ label: "archive", … }`
+
+**Acceptance:** no user-facing "archive" text remains; `node tools/check.mjs` passes; layer
+still opens/closes; aria-labels updated.
+
+---
+
+## Task 2 — Whole repository node opens the viewer
+
+**Goal:** any click anywhere on `archive-node` opens the layer, not just the `.enter` button.
+
+**File:** `scripts/app.jsx`, `archive-node` Island case (~399-415).
+- Move `onClick={onEnterArchive}` from the `.enter` button up to the node container.
+- Keep the `.enter` button as a visual affordance (it can keep its own onClick or rely on
+  bubbling). Add `role="button"` + keyboard (Enter/Space) handler + `cursor: pointer` on the
+  container for accessibility.
+- Guard against the click firing while panning if the field uses drag-to-pan (check whether a
+  drag just ended before treating it as a click).
+
+**File:** `styles/exposition.css`, `.island.archive-node` — add `cursor: pointer`, hover state
+on the whole node.
+
+**Acceptance:** clicking the mosaic, header, or empty node area opens the layer; keyboard
+activation works; panning by dragging the node does not accidentally open it.
+
+---
+
+## Task 3 — Performance: panning / scrolling is slow (esp. inside the archive)
+
+**Goal:** smooth pan on the field and smooth scroll inside the layer.
+
+**Root-cause leads (verify with DevTools Performance before fixing):**
+1. **6 auto-rotating WebGL canvases** (GLB models) each run a continuous render loop even when
+   off-screen / behind the archive layer. 54M of models. → pause rAF loops when off-viewport or
+   when `SA_ARCHIVE_OPEN`; consider `IntersectionObserver` to render only visible canvases.
+2. **49 large JPGs** (42M total, up to 4.26MB each, `assets/archive/`) with grayscale CSS filter
+   + hover transforms in the layer → decode cost + paint. → generate/downscale thumbnails for the
+   mosaic + grid; reserve full-res for single-specimen view; `content-visibility: auto` on rows.
+3. **ArchiveLayer is always mounted** (just opacity-toggled) → its 49 `<img>` decode on load.
+   → lazy-mount the grid contents, or `content-visibility`/`loading=lazy` (already lazy, confirm).
+4. **40000×40000 background grid / threads / axes** moved on every pan → large composite layers.
+   → confirm `will-change: transform` is on the moved element only, not children; check the
+   transform is GPU-composited (translate3d/scale, no layout thrash).
+
+**Acceptance:** measured improvement (frame time / dropped frames) on pan and on archive scroll;
+models don't render while the archive is open; document before/after in the PR.
+
+---
+
+## Task 4 — Data integrity: location/title/image mismatch (CRITICAL)
+
+**Goal:** the displayed name, location, and year for each specimen must match the actual antenna
+in the image. Right now the top-level `name`/`loc`/`y` look fabricated.
+
+**The problem (concrete example):** `data/archive.js` i:2 displays
+`name: "Dipole, horizontal, domestic"`, `loc: "Ramat Gan, IL"`, `y: 1964` — but its
+`notion.def`/`sub`/`urls` describe the **Holmdel Horn Antenna** (Big Bang CMB discovery, New
+Jersey). The displayed catalogue dressing is disconnected from the real antenna the Notion data
+(and the image) is about. Locations especially appear invented.
+
+**Approach:**
+- Treat `notion.def` / `notion.sub` / `notion.urls` as the truth signal for what each image
+  actually depicts (the URLs point to the real antenna).
+- For each of the 48 mapped entries: read `notion.urls` / `notion.def`, and use parallel-search
+  (`web_search` / `web_fetch`) to confirm the real antenna's name, location, and year.
+- Cross-check `data/notion-mapping.json` (0-based 0-47) ↔ `data/archive.js` (1-based i) to ensure
+  the image index points at the right Notion page in the first place. The mapping is believed to
+  exist but may itself be wrong — verify image content vs. mapped page.
+- Correct `name`, `loc`, `y` to reflect the real antenna. If a value is genuinely unknown, leave
+  it honestly blank/uncertain rather than fabricating.
+
+**Files:** `data/archive.js` (primary), `data/notion-mapping.json` (verify/correct mapping).
+
+**Acceptance:** spot-check ~10 specimens against their `notion.urls` source — name/loc/year match
+the real antenna; no invented locations; `node tools/check.mjs` passes; document method +
+per-entry corrections in the PR. This is the highest-priority correctness task.

--- a/scripts/app.jsx
+++ b/scripts/app.jsx
@@ -13,15 +13,10 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 }/*EDITMODE-END*/;
 
 const ARCHIVE = window.SA_ARCHIVE || [];
-
-// Archive entries already placed as field islands on the canvas — excluded from the grid.
-const FIELD_ARCHIVE_IS = new Set(
-  (window.SA_ISLANDS || [])
-    .filter(it => it.kind === "field" && it.img)
-    .map(it => { const m = it.img.match(/ant-(\d+)\.jpg/); return m ? parseInt(m[1], 10) + 1 : null; })
-    .filter(Boolean)
-);
-const ARCHIVE_GRID = ARCHIVE.filter(a => !FIELD_ARCHIVE_IS.has(a.i));
+// The archive browser shows the complete archive, in catalogue order.
+const ARCHIVE_ORDERED = [...ARCHIVE].sort((a, b) => a.i - b.i);
+// A spread sample used for the field node's preview mosaic.
+const ARCHIVE_PREVIEW = ARCHIVE_ORDERED.filter((_, idx) => idx % 4 === 0).slice(0, 12);
 
 // Whole-GLB specimens — each renders its own model file as a node in the field.
 const MODELS = [
@@ -37,16 +32,8 @@ const MODEL_W = 380;
 // ───────────────────────────────────────────────────────────────────────────
 // Archive photograph plate — cycles through 48 real images
 
-function Plate({ n }){
-  const idx = (n - 1).toString().padStart(2, '0');
-  return (
-    <img
-      src={`assets/archive/ant-${idx}.jpg`}
-      alt=""
-      style={{ display:'block', width:'100%', height:'100%', objectFit:'cover' }}
-    />
-  );
-}
+// Archive image src by 1-based specimen number (files are zero-padded, 0-based).
+const archiveSrc = (n) => `assets/archive/ant-${(n - 1).toString().padStart(2, '0')}.jpg`;
 
 // ───────────────────────────────────────────────────────────────────────────
 // Layout — absolute coords in the infinite plane. No section order.
@@ -54,7 +41,6 @@ function Plate({ n }){
 // (0,0) is the title; negative/positive in both axes.
 
 const GROUP_MODES = ["scatter", "application", "decade", "frequency", "type"];
-const GROUP_MODES_BIN = ["application", "decade", "frequency", "type"]; // non-scatter
 
 // Friendly label per mode — used by the tab bar, the group label meta line,
 // and the hidden picker so all three stay in lockstep.
@@ -79,63 +65,25 @@ function pickGroupKey(a, mode){
   return "all";
 }
 
-// Geometry shared between scatter and grouped layouts and the label layer.
-const ARCHIVE_LAYOUT = {
-  startX: -600,
-  scatterStartY: 1760,
-  groupedStartY: 1860,
-  groupedLabelOffsetY: -120,
-  colsInGroup: 3,
-  thumbPitchX: 130,
-  thumbPitchY: 140,
-  get colWidth(){ return this.colsInGroup * this.thumbPitchX + 40; },
-};
-
-function layoutGroupMode(mode){
+// Group the archive by a mode, returning ordered [key, list] pairs. Used by the
+// archive layer's grouped views (the field no longer lays the archive out).
+function groupArchive(mode){
   const groups = new Map();
-  for (const a of ARCHIVE_GRID){
+  for (const a of ARCHIVE_ORDERED){
     const key = pickGroupKey(a, mode);
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key).push(a);
   }
-  const ordered = [...groups.entries()].sort((A, B) => {
+  return [...groups.entries()].sort((A, B) => {
     if (A[0] === "Unspecified") return 1;
     if (B[0] === "Unspecified") return -1;
     // Decades read chronologically; all other modes stay sorted by size.
     if (mode === "decade") return parseInt(A[0], 10) - parseInt(B[0], 10);
     return B[1].length - A[1].length;
   });
-
-  const L = ARCHIVE_LAYOUT;
-  const labels = [];
-  const thumbs = [];
-  ordered.forEach(([key, list], gi) => {
-    const gx = L.startX + gi * L.colWidth;
-    labels.push({
-      id: "grp-" + mode + "-" + key.replace(/\s+/g, "_"),
-      kind: "group-label",
-      mode, x: gx, y: L.groupedStartY + L.groupedLabelOffsetY,
-      w: L.colWidth - 40, label: key, count: list.length,
-    });
-    list.forEach((a, k) => {
-      const col = k % L.colsInGroup;
-      const row = Math.floor(k / L.colsInGroup);
-      thumbs.push({ id: "arc-"+a.i, kind: "thumb",
-        x: gx + col * L.thumbPitchX,
-        y: L.groupedStartY + row * L.thumbPitchY,
-        w: 120, a
-      });
-    });
-  });
-  return { labels, thumbs };
 }
 
-// Pre-compute every label for every grouping mode. The label layer renders
-// all of them at all times, controlling visibility via opacity so the fade
-// in/out is symmetric instead of a hard mount/unmount pop.
-const ALL_GROUP_LABELS = GROUP_MODES_BIN.flatMap(m => layoutGroupMode(m).labels);
-
-function buildIslands(grouping){
+function buildIslands(){
   const items = [];
 
   // Notion-driven stable-ID islands. Sourced from data/islands.generated.js
@@ -152,31 +100,11 @@ function buildIslands(grouping){
   items.push({ id: "arc-head", kind: "cluster-head",
     x: -600, y: 1400, k: "archive", n: "gathered · ongoing"
   });
-  // In-world tab selector — sits beneath the giant "archive" wash so it reads
-  // as a section index rather than floating chrome.
-  items.push({ id: "group-tabs", kind: "group-tabs",
-    x: -600, y: 1620, w: 900
+  // The archive no longer spills across the field. A single node sits beneath
+  // the giant "archive" wash; entering it opens the full-screen archive layer.
+  items.push({ id: "archive-node", kind: "archive-node",
+    x: -600, y: 1640, w: 460
   });
-
-  if (grouping === "scatter") {
-    // Archive thumbs — seeded pseudo-random distribution (original layout)
-    let seed = 97;
-    const rand = ()=>{ seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 4294967296; };
-    for (const a of ARCHIVE_GRID){
-      const col = (a.i - 1) % 10;
-      const row = Math.floor((a.i - 1) / 10);
-      const jx = (rand() - 0.5) * 80;
-      const jy = (rand() - 0.5) * 60;
-      const baseX = ARCHIVE_LAYOUT.startX + col * 170 + jx;
-      const baseY = ARCHIVE_LAYOUT.scatterStartY + row * 220 + jy;
-      items.push({ id: "arc-"+a.i, kind: "thumb",
-        x: baseX, y: baseY, w: 120, a
-      });
-    }
-  } else {
-    const { thumbs } = layoutGroupMode(grouping);
-    items.push(...thumbs);
-  }
 
   return items;
 }
@@ -186,10 +114,10 @@ function buildIslands(grouping){
 // driven (and shifts with the `density` tweak), so vertical overlap can't be
 // known from the data. After render we measure each card's real box and nudge
 // overlapping ones apart, keeping every card as close to its authored Notion
-// position as possible. The archive grid, labels and background wash are laid
-// out deliberately, so they're excluded from packing.
-const PACK_EXCLUDE = new Set(["thumb", "group-label", "group-tabs", "cluster-head"]);
-const PACK_FIXED   = new Set(["title", "model"]); // anchors: act as obstacles, never move
+// position as possible. The background "archive" wash is laid out deliberately,
+// so it's excluded from packing.
+const PACK_EXCLUDE = new Set(["cluster-head"]);
+const PACK_FIXED   = new Set(["title", "model", "archive-node"]); // anchors: act as obstacles, never move
 const PACK_GUTTER  = 20;                  // breathing room kept between cards
 
 function boxesOverlap(a, b, g){
@@ -230,23 +158,6 @@ function packBoxes(boxes, gutter){
   }
 }
 
-// The archive (specimen grid + its tab bar) is laid out as one deliberate
-// block. We don't repack it, but it must not be covered by — or pushed under —
-// editorial cards, so we feed it in as one immovable obstacle: the union box of
-// every thumb plus the group-tabs bar. Editorial cards then flow around it.
-function archiveObstacle(islands, measured){
-  let x1 = Infinity, y1 = Infinity, x2 = -Infinity, y2 = -Infinity;
-  for (const it of islands){
-    if (it.kind !== "thumb" && it.kind !== "group-tabs") continue;
-    const m = measured[it.id];
-    const w = m ? m.w : (it.w || 120), h = m ? m.h : 120;
-    x1 = Math.min(x1, it.x); y1 = Math.min(y1, it.y);
-    x2 = Math.max(x2, it.x + w); y2 = Math.max(y2, it.y + h);
-  }
-  if (x1 === Infinity) return null;
-  return { id: "__archive__", x: x1, y: y1, w: x2 - x1, h: y2 - y1, fixed: true };
-}
-
 // Measure rendered boxes, resolve overlaps, and return id → {x, y} overrides.
 // Deterministic from the authored positions, so it converges in one re-render.
 function usePackedIslands(islands, deps){
@@ -276,8 +187,6 @@ function usePackedIslands(islands, deps){
           fixed: PACK_FIXED.has(it.kind),
         };
       });
-    const archive = archiveObstacle(islands, measured);
-    if (archive) boxes.push(archive);
     packBoxes(boxes, PACK_GUTTER);
     const next = {};
     for (const b of boxes){
@@ -366,7 +275,7 @@ const READER_PATH = [
 // ───────────────────────────────────────────────────────────────────────────
 // Islands
 
-function Island({ it, viewer, groupingCtl, pathCurrent, pathIndex }){
+function Island({ it, viewer, onEnterArchive, pathCurrent, pathIndex }){
   const style = { left: it.x + "px", top: it.y + "px", width: it.w + "px" };
 
   if (it.kind === "title") {
@@ -487,60 +396,21 @@ function Island({ it, viewer, groupingCtl, pathCurrent, pathIndex }){
     );
   }
 
-  if (it.kind === "group-label") {
+  if (it.kind === "archive-node") {
     return (
-      <div className="island group-label" style={style} data-id={it.id}>
-        <div className="meta">grouped by · {it.mode}</div>
-        <div className="lbl">{it.label}</div>
-        <div className="cnt">{it.count} specimen{it.count !== 1 ? "s" : ""}</div>
-      </div>
-    );
-  }
-
-  if (it.kind === "group-tabs") {
-    return (
-      <div className="island group-tabs" style={style} data-id={it.id}>
-        <div className="t">arrange archive by</div>
-        <div className="tabs" role="tablist">
-          {GROUP_MODES.map(m => (
-            <button key={m} role="tab"
-              aria-selected={groupingCtl.value === m}
-              className={groupingCtl.value === m ? "on" : ""}
-              onClick={()=> groupingCtl.set(m)}>
-              {MODE_LABEL[m]}
-            </button>
+      <div className="island archive-node" style={style} data-id={it.id}>
+        <div className="head">
+          <div className="k">archive</div>
+          <div className="n">{ARCHIVE_ORDERED.length} specimens · gathered, ongoing</div>
+        </div>
+        <div className="mosaic" aria-hidden="true">
+          {ARCHIVE_PREVIEW.map(a => (
+            <span key={a.i} className="cell">
+              <img loading="lazy" src={archiveSrc(a.i)} alt=""/>
+            </span>
           ))}
         </div>
-      </div>
-    );
-  }
-
-  if (it.kind === "thumb") {
-    const a = it.a;
-    return (
-      <div className="island thumb" style={style} data-id={it.id}>
-        <div className="plate"><Plate n={a.i}/></div>
-        <div className="info">
-          <div className="no">{String(a.i).padStart(3,"0")}</div>
-          <div className="nm">{a.name}</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (it.kind === "spec") {
-    const a = it.a;
-    return (
-      <div className="island spec" style={style} data-id={it.id}>
-        <div className="plate"><Plate n={a.i}/></div>
-        <div className="info">
-          <div className="no">
-            <span>{String(a.i).padStart(3,"0")}</span>
-            <span>{a.y ?? "—"}</span>
-          </div>
-          <h3>{a.name}</h3>
-          <p className="desc">{a.d}</p>
-        </div>
+        <button className="enter" onClick={onEnterArchive}>enter the archive →</button>
       </div>
     );
   }
@@ -563,27 +433,129 @@ function Island({ it, viewer, groupingCtl, pathCurrent, pathIndex }){
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Group label layer — every mode's labels stay mounted at all times. Only
-// the active mode renders opaque; the others stay at opacity 0. Switching
-// modes is then a pure crossfade rather than a DOM mount/unmount.
+// Archive layer — a full-screen browser that takes over from the field. The
+// field shrinks and fades behind it; entering is triggered by the field's
+// archive-node. It carries every grouping mode plus a single-specimen mode.
 
-function GroupLabelLayer({ labels, active }){
-  return labels.map(lbl => {
-    const visible = lbl.mode === active;
-    return (
-      <div key={lbl.id}
-        className="island group-label"
-        style={{
-          left: lbl.x + "px", top: lbl.y + "px", width: lbl.w + "px",
-          opacity: visible ? 1 : 0,
-        }}
-        aria-hidden={!visible}>
-        <div className="meta">grouped by · {MODE_LABEL[lbl.mode] || lbl.mode}</div>
-        <div className="lbl">{lbl.label}</div>
-        <div className="cnt">{lbl.count} specimen{lbl.count !== 1 ? "s" : ""}</div>
+function ArchiveThumb({ a, onOpen }){
+  return (
+    <button className="ax-thumb" onClick={()=> onOpen(a)} title={a.name}>
+      <span className="img"><img loading="lazy" src={archiveSrc(a.i)} alt=""/></span>
+      <span className="meta">
+        <span className="no">{String(a.i).padStart(3,"0")}</span>
+        <span className="nm">{a.name}</span>
+      </span>
+    </button>
+  );
+}
+
+function hostOf(u){ try { return new URL(u).hostname.replace(/^www\./, ""); } catch { return u; } }
+
+function ArchiveLayer({ open, grouping, setGrouping, onClose }){
+  const [view, setView] = React.useState("grid"); // "grid" | "specimen"
+  const [idx, setIdx]   = React.useState(0);
+
+  const openSpec = React.useCallback((a) => {
+    const i = ARCHIVE_ORDERED.findIndex(x => x.i === a.i);
+    setIdx(i < 0 ? 0 : i);
+    setView("specimen");
+  }, []);
+  const nav = React.useCallback((d) => {
+    setIdx(i => (i + d + ARCHIVE_ORDERED.length) % ARCHIVE_ORDERED.length);
+  }, []);
+
+  // Keyboard — only while the layer is open. Esc exits; arrows page the
+  // specimen. The field's own key handler stands down via window.SA_ARCHIVE_OPEN.
+  React.useEffect(()=>{
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") { onClose(); return; }
+      if (view === "specimen") {
+        if (e.key === "ArrowLeft")  { nav(-1); e.preventDefault(); }
+        if (e.key === "ArrowRight") { nav(1);  e.preventDefault(); }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return ()=> window.removeEventListener("keydown", onKey);
+  }, [open, view, nav, onClose]);
+
+  const a = ARCHIVE_ORDERED[idx];
+
+  return (
+    <div className={"archive-layer" + (open ? " open" : "")} aria-hidden={!open}>
+      <button className="ax-close" onClick={onClose} aria-label="exit the archive">×</button>
+
+      <div className="ax-bar">
+        <div className="ax-heading">archive<span>{ARCHIVE_ORDERED.length} specimens</span></div>
+        <div className="ax-tabs" role="tablist">
+          {GROUP_MODES.map(m => (
+            <button key={m} role="tab"
+              aria-selected={view === "grid" && grouping === m}
+              className={view === "grid" && grouping === m ? "on" : ""}
+              onClick={()=> { setGrouping(m); setView("grid"); }}>
+              {MODE_LABEL[m]}
+            </button>
+          ))}
+          <button role="tab"
+            aria-selected={view === "specimen"}
+            className={"spec-tab" + (view === "specimen" ? " on" : "")}
+            onClick={()=> setView("specimen")}>
+            single specimen
+          </button>
+        </div>
       </div>
-    );
-  });
+
+      <div className="ax-body">
+        {view === "grid" ? (
+          grouping === "scatter" ? (
+            <div className="ax-grid">
+              {ARCHIVE_ORDERED.map(a => <ArchiveThumb key={a.i} a={a} onOpen={openSpec}/>)}
+            </div>
+          ) : (
+            <div className="ax-groups">
+              {groupArchive(grouping).map(([key, list]) => (
+                <section className="ax-group" key={key}>
+                  <header className="ax-group-h">
+                    <span className="gmeta">grouped by · {MODE_LABEL[grouping]}</span>
+                    <span className="glbl">{key}</span>
+                    <span className="gcnt">{list.length} specimen{list.length !== 1 ? "s" : ""}</span>
+                  </header>
+                  <div className="ax-grid">
+                    {list.map(a => <ArchiveThumb key={a.i} a={a} onOpen={openSpec}/>)}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )
+        ) : (
+          <div className="ax-spec">
+            <button className="ax-spec-nav prev" onClick={()=> nav(-1)} aria-label="previous specimen">‹</button>
+            <div className="ax-spec-stage">
+              <div className="ax-spec-img"><img src={archiveSrc(a.i)} alt={a.name}/></div>
+              <div className="ax-spec-info">
+                <div className="count">{String(idx + 1).padStart(2,"0")} / {ARCHIVE_ORDERED.length}</div>
+                <div className="no">{String(a.i).padStart(3,"0")}</div>
+                <h3>{a.name}</h3>
+                <div className="facets">
+                  <span>{a.y ?? "—"}</span><span>{a.k}</span><span>{a.loc}</span>
+                </div>
+                <p className="desc">{a.d}</p>
+                {a.notion && a.notion.def && <p className="def">{a.notion.def}</p>}
+                {a.notion && Array.isArray(a.notion.urls) && a.notion.urls.length > 0 && (
+                  <ul className="links">
+                    {a.notion.urls.map((u, i) => (
+                      <li key={i}><a href={u} target="_blank" rel="noopener noreferrer">{hostOf(u)} ↗</a></li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+            <button className="ax-spec-nav next" onClick={()=> nav(1)} aria-label="next specimen">›</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -598,8 +570,7 @@ function Threads({ islands, threads, show }){
     const hByKind = {
       title: 360, prose: 180, pullquote: 200, whisper: 80, note: 80,
       field: 340, gloss: 130, method: 280, bib: 340, colophon: 160,
-      "cluster-head": 280, thumb: 170, spec: 300, model: 345,
-      "group-label": 100, "group-tabs": 64
+      "cluster-head": 280, model: 345, "archive-node": 360,
     };
     const h = hByKind[it.kind] || 160;
     const w = it.w || 240;
@@ -706,6 +677,7 @@ function Viewport({ children, onPose }){
       apply();
     };
     const onKey = (e) => {
+      if (window.SA_ARCHIVE_OPEN) return;
       const s = stateRef.current;
       const step = 120;
       if (e.key === "ArrowLeft")  { s.x += step; apply(); }
@@ -761,20 +733,28 @@ function App(){
   const [groupPicker, setGroupPicker] = React.useState(false);
   const [pathMode, setPathMode] = React.useState(false);
   const [pathStep, setPathStep] = React.useState(0);
+  const [archiveOpen, setArchiveOpen] = React.useState(false);
 
+  // The archive layer's arrangement mode is the same `grouping` tweak the
+  // hidden picker drives, so both stay in lockstep.
   const grouping = GROUP_MODES.includes(t.grouping) ? t.grouping : "scatter";
-  const baseIslands = React.useMemo(()=> buildIslands(grouping), [grouping]);
+  const baseIslands = React.useMemo(()=> buildIslands(), []);
   // Nudge overlapping cards apart using their real measured heights; re-runs
-  // when the layout (grouping) or card sizing (density) changes.
+  // when card sizing (density) changes.
   const islands = usePackedIslands(baseIslands, [baseIslands, t.density]);
-  const groupingCtl = React.useMemo(()=> ({
-    value: grouping,
-    set: (m) => setTweak("grouping", m),
-  }), [grouping, setTweak]);
 
-  // Hidden grouping picker — press `g` to toggle, Esc to close.
+  // Shrink + fade the field behind the archive layer, and tell the field's
+  // key/pointer handlers to stand down while the archive is open.
+  React.useEffect(()=>{
+    document.body.classList.toggle("sa-archive-open", archiveOpen);
+    window.SA_ARCHIVE_OPEN = archiveOpen;
+  }, [archiveOpen]);
+
+  // Hidden grouping picker — press `g` to toggle, Esc to close. Inert while
+  // the archive layer owns the keyboard.
   React.useEffect(()=>{
     const onKey = (e) => {
+      if (window.SA_ARCHIVE_OPEN) return;
       const tag = e.target && e.target.tagName;
       if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
       if (e.key === "g" || e.key === "G") {
@@ -787,9 +767,6 @@ function App(){
     window.addEventListener("keydown", onKey);
     return ()=> window.removeEventListener("keydown", onKey);
   }, []);
-  // Drop dynamic-archive threads whose endpoint thumbs no longer share the
-  // featured layout; the curated THREADS list addresses sp-N + arc-head only,
-  // both of which stay put, so the list itself is grouping-independent.
   const threads = THREADS;
 
   function goToIsland(id) {
@@ -823,8 +800,7 @@ function App(){
   const jumps = [
     { label: "title",    x: 0,    y: 0 },
     { label: "essay",    x: 1400, y: 120 },
-    { label: "specimen", x: 720,  y: 420 },
-    { label: "archive",  x: 360,  y: 2200 },
+    { label: "archive",  x: -370, y: 1740 },
     { label: "field",    x: -400, y: 500 },
     { label: "sources",  x: -1280, y: -80 },
   ];
@@ -837,11 +813,17 @@ function App(){
         <Threads islands={islands} threads={threads} show={t.threads}/>
         {islands.map(it => {
           const pathIdx = pathMode ? READER_PATH.indexOf(it.id) : -1;
-          return <Island key={it.id} it={it} viewer={viewer} groupingCtl={groupingCtl}
+          return <Island key={it.id} it={it} viewer={viewer} onEnterArchive={()=> setArchiveOpen(true)}
             pathCurrent={pathIdx === pathStep} pathIndex={pathIdx >= 0 ? pathIdx + 1 : 0}/>;
         })}
-        <GroupLabelLayer labels={ALL_GROUP_LABELS} active={grouping}/>
       </Viewport>
+
+      <ArchiveLayer
+        open={archiveOpen}
+        grouping={grouping}
+        setGrouping={(m)=> setTweak("grouping", m)}
+        onClose={()=> setArchiveOpen(false)}
+      />
 
 
       <div className="chrome">

--- a/styles/exposition.css
+++ b/styles/exposition.css
@@ -646,17 +646,20 @@ body.sa-archive-open .chrome{ opacity: 0; pointer-events: none; transition: opac
 
 .archive-layer .ax-body{ flex: 1 1 auto; overflow-y: auto; overflow-x: hidden; }
 
-/* grid + grouped views */
+/* grid + grouped views — separators are drawn per-thumb so an incomplete
+   last row leaves white space, not a black stub, where the category ends. */
 .archive-layer .ax-grid{
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 1px; background: var(--ink);
-  border-bottom: 1px solid var(--ink);
+  gap: 0; background: var(--paper);
+  border-left: 1px solid var(--ink);
 }
 .archive-layer .ax-groups .ax-grid{ margin: 0; }
 .archive-layer .ax-thumb{
   display: flex; flex-direction: column; text-align: left;
-  background: var(--paper); border: 0; padding: 0; cursor: pointer;
+  background: var(--paper);
+  border: 0; border-right: 1px solid var(--ink); border-bottom: 1px solid var(--ink);
+  padding: 0; cursor: pointer;
   font: inherit; color: inherit;
 }
 .archive-layer .ax-thumb .img{ aspect-ratio: 1/1; overflow: hidden; }

--- a/styles/exposition.css
+++ b/styles/exposition.css
@@ -407,51 +407,6 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
 .island.viewer .meta dt{ color: var(--muted); text-transform:uppercase; letter-spacing:.12em }
 .island.viewer .meta dd{ margin:0; font-variant-numeric: tabular-nums }
 
-/* specimen plate (single archive entry as a loose card) */
-.island.spec{
-  width: 220px;
-  padding: 0;
-  border: 1px solid var(--ink);
-}
-.island.spec .plate{
-  border-bottom: 1px solid var(--ink);
-  aspect-ratio: 5/4;
-  position:relative;
-  background: var(--paper);
-  overflow:hidden;
-}
-.island.spec .plate svg{ display:block; width:100%; height:100% }
-.island.spec .plate img{
-  display:block; width:100%; height:100%; object-fit:cover;
-  filter: grayscale(1) contrast(1.05);
-  transition: filter .35s ease;
-}
-.island.spec .info{ padding: .5rem .6rem .7rem }
-.island.spec .no{
-  font-family: var(--f-mono); font-size: 10px;
-  letter-spacing:.14em; text-transform:uppercase;
-  color: var(--muted);
-  display:flex; justify-content: space-between;
-}
-.island.spec h3{
-  margin: .15rem 0 .2rem;
-  font-family: var(--f-grot); font-weight: 500;
-  font-size: 13px; line-height:1.2; letter-spacing:-.005em;
-}
-.island.spec dl{
-  margin:0; font-family: var(--f-mono);
-  font-size: 10px;
-  display:grid; grid-template-columns: 4ch 1fr; gap: 0 .4rem;
-}
-.island.spec dl dt{ color: var(--muted); text-transform:uppercase }
-.island.spec dl dd{ margin:0 }
-.island.spec .desc{
-  margin-top:.45rem;
-  font-family: var(--f-serif); font-size: 11.5px; line-height: 1.4;
-}
-
-/* archive constellation (80 specimens loose in the plane — drawn by JS) */
-
 /* field plate (photograph island) */
 .island.field{ padding: 0; border: 1px solid var(--ink); width: 420px; }
 .island.field .fig{
@@ -578,96 +533,251 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
   text-transform: none; letter-spacing: 0; font-size: 13px; color: var(--muted);
 }
 
-/* specimen archive — dense scatter: small thumbs */
-.island.thumb{
-  width: 120px; padding: 0; border: 1px solid var(--ink);
+/* ── archive node — the field's single doorway into the archive ──────────── */
+.island.archive-node{
+  padding: 0; border: 1px solid var(--ink);
   background: var(--paper);
+  cursor: default;
 }
-.island.thumb .plate{
+.island.archive-node .head{
+  padding: .55rem .7rem .5rem;
   border-bottom: 1px solid var(--ink);
-  aspect-ratio: 1/1;
-  position: relative;
-  overflow:hidden;
 }
-.island.thumb .plate svg{ display:block; width:100%; height:100% }
-.island.thumb .plate img{
-  display:block; width:100%; height:100%; object-fit:cover;
-  filter: grayscale(1) contrast(1.05);
-  transition: filter .35s ease;
-}
-/* Hover any archive specimen → fade in the original colour photograph. */
-.island.thumb:hover .plate img,
-.island.spec:hover  .plate img{ filter: none; }
-.island.thumb .info{ padding: .3rem .4rem .4rem }
-.island.thumb .no{
-  font-family: var(--f-mono); font-size: 9.5px; letter-spacing:.14em;
-  color: var(--muted); text-transform:uppercase;
-}
-.island.thumb .nm{
+.island.archive-node .head .k{
   font-family: var(--f-grot); font-weight: 500;
-  font-size: 10.5px; line-height: 1.15; letter-spacing:-.005em;
-  margin-top: .1rem;
+  font-size: 1.5rem; line-height: 1; letter-spacing: -.02em;
 }
-
-/* archive grouping: animate thumbs as they re-flow into clusters */
-.island.thumb{
-  transition: left .85s cubic-bezier(.45,.05,.2,1),
-              top  .85s cubic-bezier(.45,.05,.2,1);
+.island.archive-node .head .n{
+  margin-top: .25rem;
+  font-family: var(--f-mono); font-size: 10px;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--muted);
 }
-
-/* group-tabs — in-world tab bar that sets the archive grouping mode */
-.island.group-tabs{
-  background: transparent; border: 0; padding: 0;
+.island.archive-node .mosaic{
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px;
+  background: var(--ink);
+  border-bottom: 1px solid var(--ink);
 }
-.island.group-tabs .t{
-  font-family: var(--f-mono); font-size: 10.5px;
-  letter-spacing: .18em; text-transform: uppercase;
-  color: var(--muted);
-  margin-bottom: .4rem;
+.island.archive-node .mosaic .cell{
+  aspect-ratio: 1/1; overflow: hidden; background: var(--paper);
 }
-.island.group-tabs .tabs{
-  display: inline-flex; flex-wrap: wrap;
-  border: 1px solid var(--ink);
-  background: var(--paper);
+.island.archive-node .mosaic img{
+  display: block; width: 100%; height: 100%; object-fit: cover;
+  filter: grayscale(1) contrast(1.05);
+  transition: filter .4s ease, transform .4s ease;
 }
-.island.group-tabs .tabs button{
+.island.archive-node:hover .mosaic img{ filter: none; }
+.island.archive-node .enter{
+  display: block; width: 100%;
   font-family: var(--f-mono); font-size: 12px;
-  letter-spacing: .14em; text-transform: uppercase;
+  letter-spacing: .16em; text-transform: uppercase;
+  background: var(--paper); color: var(--ink);
+  border: 0; padding: .7rem .8rem; text-align: left;
+  cursor: pointer;
+  transition: background .18s ease, color .18s ease, letter-spacing .25s ease;
+}
+.island.archive-node:hover .enter,
+.island.archive-node .enter:hover{
+  background: var(--ink); color: var(--paper); letter-spacing: .22em;
+}
+
+/* ── archive layer — full-screen takeover ────────────────────────────────── */
+/* The field shrinks and fades behind it. */
+.viewport{ transition: transform .5s cubic-bezier(.4,0,.2,1), opacity .5s ease, filter .5s ease; }
+body.sa-archive-open .viewport{
+  transform: scale(.92); opacity: .12; filter: saturate(0);
+  pointer-events: none;
+}
+body.sa-archive-open .chrome{ opacity: 0; pointer-events: none; transition: opacity .35s ease; }
+
+.archive-layer{
+  position: fixed; inset: 0; z-index: 1600;
+  background: var(--paper); color: var(--ink);
+  display: flex; flex-direction: column;
+  opacity: 0; visibility: hidden;
+  transform: scale(1.04);
+  transition: opacity .45s ease, transform .45s cubic-bezier(.2,.7,.3,1), visibility 0s linear .45s;
+}
+.archive-layer.open{
+  opacity: 1; visibility: visible; transform: scale(1);
+  transition: opacity .45s ease, transform .45s cubic-bezier(.2,.7,.3,1), visibility 0s;
+}
+.archive-layer .ax-close{
+  position: absolute; top: .6rem; left: .8rem; z-index: 3;
+  width: 56px; height: 56px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--f-grot); font-size: 2.6rem; line-height: 1;
+  background: var(--paper); color: var(--ink);
+  border: 1px solid var(--ink); cursor: pointer;
+  transition: background .18s ease, color .18s ease, transform .18s ease;
+}
+.archive-layer .ax-close:hover{ background: var(--ink); color: var(--paper); transform: rotate(90deg); }
+
+.archive-layer .ax-bar{
+  flex: 0 0 auto;
+  display: flex; align-items: flex-end; gap: 1.5rem;
+  padding: .7rem 1rem .7rem 5.5rem;
+  border-bottom: 1px solid var(--ink);
+}
+.archive-layer .ax-heading{
+  font-family: var(--f-grot); font-weight: 500;
+  font-size: 1.7rem; line-height: 1; letter-spacing: -.02em;
+  display: flex; align-items: baseline; gap: .6rem;
+}
+.archive-layer .ax-heading span{
+  font-family: var(--f-mono); font-size: 10px; font-weight: 400;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--muted);
+}
+.archive-layer .ax-tabs{
+  display: inline-flex; flex-wrap: wrap; margin-left: auto;
+  border: 1px solid var(--ink);
+}
+.archive-layer .ax-tabs button{
+  font-family: var(--f-mono); font-size: 11px;
+  letter-spacing: .12em; text-transform: uppercase;
   background: var(--paper); border: 0;
   border-left: 1px solid var(--ink);
-  padding: .55rem 1.1rem; color: var(--ink);
+  padding: .5rem .9rem; color: var(--ink); cursor: pointer;
+  transition: background .18s ease, color .18s ease;
+}
+.archive-layer .ax-tabs button:first-child{ border-left: 0 }
+.archive-layer .ax-tabs button:hover{ background: var(--ink); color: var(--paper); }
+.archive-layer .ax-tabs button.on{ background: var(--ink); color: var(--paper); }
+.archive-layer .ax-tabs button.spec-tab{ border-left-width: 3px; }
+
+.archive-layer .ax-body{ flex: 1 1 auto; overflow-y: auto; overflow-x: hidden; }
+
+/* grid + grouped views */
+.archive-layer .ax-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1px; background: var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+.archive-layer .ax-groups .ax-grid{ margin: 0; }
+.archive-layer .ax-thumb{
+  display: flex; flex-direction: column; text-align: left;
+  background: var(--paper); border: 0; padding: 0; cursor: pointer;
+  font: inherit; color: inherit;
+}
+.archive-layer .ax-thumb .img{ aspect-ratio: 1/1; overflow: hidden; }
+.archive-layer .ax-thumb img{
+  display: block; width: 100%; height: 100%; object-fit: cover;
+  filter: grayscale(1) contrast(1.05);
+  transition: filter .35s ease, transform .6s ease;
+}
+.archive-layer .ax-thumb:hover img{ filter: none; transform: scale(1.04); }
+.archive-layer .ax-thumb .meta{ padding: .35rem .5rem .55rem; }
+.archive-layer .ax-thumb .no{
+  display: block;
+  font-family: var(--f-mono); font-size: 9.5px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--muted);
+}
+.archive-layer .ax-thumb .nm{
+  display: block; margin-top: .1rem;
+  font-family: var(--f-grot); font-weight: 500;
+  font-size: 11px; line-height: 1.15; letter-spacing: -.005em;
+}
+.archive-layer .ax-thumb:hover{ outline: 2px solid var(--ink); outline-offset: -2px; z-index: 1; }
+
+.archive-layer .ax-group{ border-bottom: 1px solid var(--ink); }
+.archive-layer .ax-group-h{
+  display: flex; align-items: baseline; gap: .8rem;
+  padding: .8rem 1rem .55rem;
+  position: sticky; top: 0; z-index: 2;
+  background: var(--paper);
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 18%, transparent);
+}
+.archive-layer .ax-group-h .gmeta{
+  font-family: var(--f-mono); font-size: 9.5px;
+  letter-spacing: .16em; text-transform: uppercase; color: var(--muted);
+}
+.archive-layer .ax-group-h .glbl{
+  font-family: var(--f-grot); font-weight: 500;
+  font-size: 1.3rem; line-height: 1; letter-spacing: -.012em;
+}
+.archive-layer .ax-group-h .gcnt{
+  margin-left: auto;
+  font-family: var(--f-mono); font-size: 10px;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--muted);
+}
+
+/* single-specimen view */
+.archive-layer .ax-spec{
+  height: 100%;
+  display: grid; grid-template-columns: 64px 1fr 64px;
+}
+.archive-layer .ax-spec-nav{
+  background: var(--paper); border: 0;
+  border-right: 1px solid var(--ink);
+  font-family: var(--f-grot); font-size: 2.4rem; color: var(--ink);
   cursor: pointer;
   transition: background .18s ease, color .18s ease;
 }
-.island.group-tabs .tabs button:first-child{ border-left: 0 }
-.island.group-tabs .tabs button:hover{ background: var(--ink); color: var(--paper) }
-.island.group-tabs .tabs button.on{
-  background: var(--ink); color: var(--paper);
+.archive-layer .ax-spec-nav.next{ border-right: 0; border-left: 1px solid var(--ink); }
+.archive-layer .ax-spec-nav:hover{ background: var(--ink); color: var(--paper); }
+.archive-layer .ax-spec-stage{
+  display: grid; grid-template-columns: 1.6fr 1fr; min-height: 0;
 }
-
-/* group-label island — every grouping mode's labels are mounted at once;
-   only the active mode renders opaque so switching is a symmetric crossfade. */
-.island.group-label{
-  background: transparent; border: 0; padding: 0;
-  pointer-events: none;
-  transition: opacity .55s ease;
+.archive-layer .ax-spec-img{
+  display: flex; align-items: center; justify-content: center;
+  padding: 2.2rem; min-height: 0;
+  border-right: 1px solid var(--ink);
+  background:
+    repeating-linear-gradient(45deg, #00000005 0 8px, transparent 8px 16px);
 }
-.island.group-label .meta{
-  font-family: var(--f-mono); font-size: 9.5px;
-  letter-spacing: .16em; text-transform: uppercase;
-  color: var(--muted);
+.archive-layer .ax-spec-img img{
+  max-width: 100%; max-height: 100%; object-fit: contain;
+  box-shadow: 0 18px 50px rgba(0,0,0,.18);
 }
-.island.group-label .lbl{
-  margin-top: .15rem;
+.archive-layer .ax-spec-info{
+  padding: 2.2rem 2rem; overflow-y: auto;
+}
+.archive-layer .ax-spec-info .count{
+  font-family: var(--f-mono); font-size: 11px;
+  letter-spacing: .2em; text-transform: uppercase; color: var(--muted);
+}
+.archive-layer .ax-spec-info .no{
+  margin-top: 1rem;
+  font-family: var(--f-mono); font-size: 12px;
+  letter-spacing: .18em; color: var(--dim);
+}
+.archive-layer .ax-spec-info h3{
+  margin: .2rem 0 .8rem;
   font-family: var(--f-grot); font-weight: 500;
-  font-size: 1.65rem; line-height: 1.05; letter-spacing: -.012em;
-  color: var(--ink);
+  font-size: 1.9rem; line-height: 1.05; letter-spacing: -.02em;
 }
-.island.group-label .cnt{
-  margin-top: .2rem;
-  font-family: var(--f-mono); font-size: 10px;
-  letter-spacing: .14em; text-transform: uppercase;
+.archive-layer .ax-spec-info .facets{
+  display: flex; flex-wrap: wrap; gap: .4rem .8rem;
+  font-family: var(--f-mono); font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase; color: var(--muted);
+  padding-bottom: .8rem; margin-bottom: .8rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 18%, transparent);
+}
+.archive-layer .ax-spec-info .desc{
+  font-family: var(--f-serif); font-size: 14px; line-height: 1.5;
+}
+.archive-layer .ax-spec-info .def{
+  margin-top: 1rem;
+  font-family: var(--f-serif); font-size: 13px; line-height: 1.55;
   color: var(--muted);
+}
+.archive-layer .ax-spec-info .links{
+  margin: 1.2rem 0 0; padding: 0; list-style: none;
+  display: flex; flex-direction: column; gap: .3rem;
+}
+.archive-layer .ax-spec-info .links a{
+  font-family: var(--f-mono); font-size: 11px;
+  letter-spacing: .06em; color: var(--ink);
+  text-decoration: none; border-bottom: 1px solid var(--faint);
+}
+.archive-layer .ax-spec-info .links a:hover{ border-bottom-color: var(--ink); }
+
+@media (max-width: 720px){
+  .archive-layer .ax-bar{ padding-left: 4.5rem; flex-wrap: wrap; gap: .6rem; }
+  .archive-layer .ax-tabs{ margin-left: 0; }
+  .archive-layer .ax-spec{ grid-template-columns: 48px 1fr 48px; }
+  .archive-layer .ax-spec-stage{ grid-template-columns: 1fr; }
+  .archive-layer .ax-spec-img{ border-right: 0; border-bottom: 1px solid var(--ink); }
 }
 
 /* cluster header (subtle ground-text like "archive", "essay") */
@@ -687,7 +797,7 @@ html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);
 }
 
 /* hover affordance — specimens */
-.island.spec:hover, .island.thumb:hover, .island.field:hover{
+.island.field:hover{
   box-shadow: inset 0 0 0 2px var(--ink);
 }
 
@@ -701,7 +811,6 @@ body[data-density="compact"] .island.prose-frag{ width: 400px }
 body[data-density="compact"] .island.prose-frag .body p{ font-size: 13px }
 body[data-density="archival"] .island.prose-frag{ width: 340px }
 body[data-density="archival"] .island.prose-frag .body p{ font-size: 12px }
-body[data-density="archival"] .island.thumb{ width: 92px }
 
 body[data-numbering="roman"] .figno .n{ font-variant: small-caps; font-family: var(--f-serif); }
 


### PR DESCRIPTION
## Summary
- Replace the archive thumbs scattered across the exposition with a single **archive node** in the field: a card with a preview mosaic and a hover-revealed "enter the archive →" button.
- Entering opens a **full-screen archive layer**. The field shrinks + fades behind it (`body.sa-archive-open`); a large **×** top-left exits. Keyboard `Esc` also exits; the field's pan keys and `g` picker stand down via `window.SA_ARCHIVE_OPEN`.
- The layer carries **every existing grouping mode** (scatter, application, decade, band, form) **plus a new single-specimen mode**: a full-screen contained image with metadata (number, name, facets, Notion definition + links) and wrapping prev/next nav (`←`/`→`). Clicking any thumbnail jumps straight in.
- Removed the now-dead field machinery: scattered `thumb` islands, in-world `group-tabs`, the `group-label` crossfade layer, and their geometry helpers (`layoutGroupMode`, `ARCHIVE_LAYOUT`, `ALL_GROUP_LABELS`, `archiveObstacle`).

## Test plan
- [x] `node tools/check.mjs` passes (60 thread edges, 47 mappings)
- [x] Archive node renders preview mosaic + enter button; no console errors
- [x] Enter takes over full screen; field shrinks/fades; chrome hidden
- [x] Scatter grid, grouped sections (sticky headers + counts), single-specimen all render
- [x] Specimen prev/next nav works; thumbnail click opens specimen
- [x] × and Esc exit; field restores to opacity 1 / no transform
- [ ] Spot-check on a narrow viewport (responsive rules added but not dogfooded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)