### PR TITLE
MHRA References + JAR abstract; note RC transition

### DIFF
--- a/.claude/rc-build/BUILD_PLAN.md
+++ b/.claude/rc-build/BUILD_PLAN.md
@@ -30,8 +30,18 @@ so the RC canvas needs to be ~8800×5400.
 - [ ] #5 Build all static text islands at original scatter coords (12 placed so far, see below)
 - [ ] #6 Place archive slideshow + model clips into the layout
 - [ ] #7 Recreate the 39 inter-island threads with the shape tool
-- [ ] #8 Convert bibliography to MHRA author-date References
-- [ ] #9 JAR metadata: license, abstract (125–250 words), ≥5 keywords, linked TOC (RC TOC tool), title/author
+- [x] #8 Convert bibliography to MHRA author-date References — done in Notion (`bib` row renamed "References"); RC-ready text + abstract/keywords in [JAR_METADATA.md](./JAR_METADATA.md)
+- [ ] #9 JAR metadata: license, abstract (125–250 words), ≥5 keywords, linked TOC (RC TOC tool), title/author — abstract + keywords drafted in [JAR_METADATA.md](./JAR_METADATA.md)
+
+## Note — exposition is moving into RC (parser path now secondary)
+Content authoring is transitioning **from the website into the Research Catalogue editor itself**.
+As a result, the Notion → `tools/sync-from-notion.mjs` → `data/islands.generated.js` pipeline (and
+the website render in `scripts/app.jsx`) is **no longer the primary surface** — it stays as the
+content-of-record but is not where the published exposition is built. Practical implications:
+- Edits to fragment *content* (incl. the References list) still go in Notion as source of truth, but
+  the generated JS / website rendering is secondary; don't block on re-running the sync.
+- New formatting (e.g. the "References" section heading, MHRA author-date entries) is authored for
+  the **RC text boxes**; the website `bib` island renders only a bare numbered list with no heading.
 
 ## Boxes already created in RC (vertical column — STILL NEED repositioning to scatter)
 | island | RC data-id | orig x | orig y |

--- a/.claude/rc-build/JAR_METADATA.md
+++ b/.claude/rc-build/JAR_METADATA.md
@@ -1,0 +1,31 @@
+# JAR submission metadata — Speculative Antennology
+
+Drafts for BUILD_PLAN task #9 (JAR metadata: license, abstract, keywords, linked TOC, title/author).
+The bibliography/reference list is formatted in **MHRA author-date** and the section is titled
+**References** per the JAR submission checklist (source of truth: the `bib` row, now named
+"References", in the Notion *Exposition Text Fragments* DB).
+
+## Abstract (≈210 words; JAR requires 125–250)
+
+Speculative Antennology proposes a discipline whose object is not the function of the antenna
+but its form, placement, biography, and cultural situation. Gathering antennas — biological and
+engineered, terrestrial and orbital — as cultural specimens rather than technical instruments, the
+exposition asks how art might operate when the sensible is no longer the measure of the real. It
+begins from the narrowness of the human sensorium and dwells in the discrepancy between worldly
+activity and human apprehension: energies that act before they appear, transmissions that cross
+space before they are received, fields that condition experience without becoming objects of
+experience.
+
+Across a pannable field of essays, glossary entries, field photographs, and archival images, the
+project assembles a practice that thinks *with* electromagnetism rather than illustrating it. Robert
+Barry's buried radiation, projected and solid light, desert lightning fields, radio-telescope arrays,
+carrier waves, seismometer-modulated orbital transmission, and computational simulation become
+points in a diagram of energetic thought. Drawing on elemental media theory and the physics of the
+electromagnetic memory effect, it argues that energy, too, remembers — that events may leave traces
+which are field-like rather than objectual. The exposition does not close the field but makes it
+available as field: charged, partial, distributed, and still receiving.
+
+## Keywords (≥5 required)
+
+antennas; electromagnetism; elemental media; imperceptibility; artistic research; energetic memory;
+radio sculpture; media archaeology

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Speculative Antennology — project memory
 
+> **Transition in progress:** the exposition is being rebuilt inside the Research Catalogue (RC)
+> editor for JAR submission (see `.claude/rc-build/BUILD_PLAN.md`). The website + Notion →
+> `islands.generated.js` pipeline below remains the content-of-record but is **no longer the primary
+> publishing surface**. Edit fragment content in Notion as before; the generated JS / website render
+> is now secondary.
+
 ## Run / build
 - Static site, no build step. `index.html` loads JSX via Babel standalone — do not run `npm install`.
 - Open `index.html` directly in a browser, or serve with `python3 -m http.server`.


### PR DESCRIPTION
## Summary
- Add `.claude/rc-build/JAR_METADATA.md`: JAR abstract (125–250 words) + ≥5 keywords.
- Mark BUILD_PLAN #8 (MHRA References) done; annotate #9 (JAR metadata).
- Note in `CLAUDE.md` that the exposition is moving into the Research Catalogue editor — the Notion→`islands.generated.js` parser path is now secondary.

The References list itself (28 MHRA author-date entries, section titled "References") lives in the Notion *Exposition Text Fragments* DB (`bib` row), not in this repo. The website `bib` island still renders the prior generated list until `sync-from-notion.mjs` is re-run, which is intentional given the RC transition.

## Test plan
- [ ] Confirm Notion References page reads correctly (28 entries, author-date, italicized titles)
- [ ] Confirm abstract is within 125–250 words and keywords ≥5